### PR TITLE
Allow CURDAY overrule in DEFAULTSFILE

### DIFF
--- a/atop.daily
+++ b/atop.daily
@@ -4,6 +4,7 @@ LOGOPTS=""				# default options
 LOGINTERVAL=600				# default interval in seconds
 LOGGENERATIONS=28			# default number of days
 LOGPATH=/var/log/atop                   # default log location
+CURDAY=`date +%Y%m%d`			# default atop rawlog suffix
 
 # allow administrator to overrule the variables
 # defined above
@@ -24,7 +25,6 @@ then
 	esac
 fi
 
-CURDAY=`date +%Y%m%d`
 BINPATH=/usr/bin
 PIDFILE=/var/run/atop.pid
 


### PR DESCRIPTION
This change can help overriding the CURDAY suffix without touching the atop.daily file.
See discussion in https://github.com/Atoptool/atop/issues/140.